### PR TITLE
Specify input types on KFP components

### DIFF
--- a/component-catalog-connectors/kfp-example-components-connector/kfp_examples_connector/resources/calculate_hash.yaml
+++ b/component-catalog-connectors/kfp-example-components-connector/kfp_examples_connector/resources/calculate_hash.yaml
@@ -1,6 +1,6 @@
 name: Calculate data hash
 inputs:
-- {name: Data}
+- {name: Data, type: Artifact}
 - {name: Hash algorithm, type: String, default: SHA256, description: "Hash algorithm to use. Supported values are MD5, SHA1, SHA256, SHA512, SHA3"}
 outputs:
 - {name: Hash}

--- a/component-catalog-connectors/kfp-example-components-connector/kfp_examples_connector/resources/download_data.yaml
+++ b/component-catalog-connectors/kfp-example-components-connector/kfp_examples_connector/resources/download_data.yaml
@@ -1,7 +1,7 @@
 name: Download data
 inputs:
-- {name: Url, type: URI}
-- {name: curl options, type: string, default: '--location', description: 'Additional options given to the curl program. See https://curl.haxx.se/docs/manpage.html'}
+- {name: Url, type: String}
+- {name: curl options, type: String, default: '--location', description: 'Additional options given to the curl program. See https://curl.haxx.se/docs/manpage.html'}
 outputs:
 - {name: Data}
 metadata:

--- a/component-catalog-connectors/kfp-example-components-connector/kfp_examples_connector/resources/filter_text_using_shell_and_grep.yaml
+++ b/component-catalog-connectors/kfp-example-components-connector/kfp_examples_connector/resources/filter_text_using_shell_and_grep.yaml
@@ -18,7 +18,7 @@ name: Filter text
 description: Filter input text according to the given regex pattern using shell and grep.
 inputs:
 - {name: Text, optional: false, description: 'Path to file to be filtered'}
-- {name: Pattern, optional: true, default: '.*', description: 'Regex pattern'}
+- {name: Pattern, type: String, optional: true, default: '.*', description: 'Regex pattern'}
 outputs:
 - {name: Filtered text}
 metadata:
@@ -35,7 +35,7 @@ implementation:
       pattern=$1
       filtered_text_path=$2
       mkdir -p "$(dirname "$filtered_text_path")"
-      
+
       grep "$pattern" < "$text_path" > "$filtered_text_path"
     - {inputPath: Text}
     - {inputValue: Pattern}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/main/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/main/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->
This PR specifies the correct types for inputs on KFP components compatible with KFP v2. This change is necessary because the assets in this library are being used by Elyra tests and the [ODH fork](https://github.com/opendatahub-io/elyra/) has upgraded KFP to v2. 

The tests that need this change are:
- `test_pipeline_app.py::test_export_kubeflow_output_option`
- `test_pipeline_app.py::test_export_kubeflow_overwrite_option`
- `test_pipeline_app.py::test_export_kubeflow_format_option`

### How was this pull request tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I have forked this repository with these changes and referenced the `elyra-examples-kfp-catalog` package in the `test_requirements.txt` like the following, to pick up my changes:
```
git+https://github.com/caponetto/elyra-ai-examples.git@68de2c86f9102cb78abeba3ae8a95ceb826bd179#egg=elyra-examples-kfp-catalog&subdirectory=component-catalog-connectors/kfp-example-components-connector
```

With these changes, the tests pass.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
